### PR TITLE
Make yaha compatible with py3

### DIFF
--- a/extra/idf_maker.py
+++ b/extra/idf_maker.py
@@ -45,8 +45,8 @@ def _from_python(value):
         else:
             value = 'false'
     elif isinstance(value, (list, tuple)):
-        value = u','.join([force_unicode(v) for v in value])
-    elif isinstance(value, (int, long, float)):
+        value = ','.join([force_unicode(v) for v in value])
+    elif isinstance(value, (int, float)):
         # Leave it alone.
         pass
     else:
@@ -66,11 +66,11 @@ schema_fields = {
 schema_fields[index_fieldname] = TEXT(stored=True, analyzer=ChineseAnalyzer())
 schema = Schema(**schema_fields)
 
-accepted_chars = re.compile(ur"[\u4E00-\u9FA5]+", re.UNICODE)
-accepted_line = re.compile(ur"\d+-\d+-\d+")
+accepted_chars = re.compile(r"[\u4E00-\u9FA5]+", re.UNICODE)
+accepted_line = re.compile(r"\d+-\d+-\d+")
 
 def get_content(filename):
-    accepted_line = re.compile(ur"\d+-\d+-\d+")
+    accepted_line = re.compile(r"\d+-\d+-\d+")
     file = codecs.open(filename, 'r', 'utf-8')
     content = ''
     names = []
@@ -108,7 +108,7 @@ def add_doc():
         writer.add_document(**doc)
         writer.commit()
         #writer.update_document(**doc)
-    except Exception, e:
+    except Exception as e:
         raise
 
 def write_db():
@@ -123,7 +123,7 @@ def write_db():
         doc[index_fieldname] = text
         try:
             writer.update_document(**doc)
-        except Exception, e:
+        except Exception as e:
             raise
 
     #add_doc(index, writer)
@@ -161,13 +161,13 @@ def search_db():
     for keyword, score in raw_results.key_terms(index_fieldname, docs=1000, numterms=240):
         if keyword in names:
             continue
-        if terms.has_key(keyword):
-            if not n_terms.has_key(keyword):
+        if keyword in terms:
+            if keyword not in n_terms:
                 keys.append(keyword)
-            elif n_terms.has_key(keyword) and n_terms[keyword].find('n')>=0:
+            elif keyword in n_terms and n_terms[keyword].find('n')>=0:
                 keys.append(keyword)
         #keys.append(keyword)
-    print ', '.join(keys)
+    print(', '.join(keys))
     #print len(raw_results)
     #for result in raw_results:
     #    print result[index_fieldname]
@@ -178,7 +178,7 @@ def key_all():
     reader = searcher.reader()
     cnt = 0
     filename = 'idf.txt'
-    accepted_chars = re.compile(ur"[\u4E00-\u9FA5]+", re.UNICODE)
+    accepted_chars = re.compile(r"[\u4E00-\u9FA5]+", re.UNICODE)
     file = codecs.open(filename, "w", "utf-8")
     file.write('%s\n' % reader.doc_count_all() )
     for term in reader.field_terms('content'):

--- a/tests/test_cuttor.py
+++ b/tests/test_cuttor.py
@@ -1,26 +1,26 @@
 # -*- coding=utf-8 -*-
-import sys, re, codecs
+import re, codecs
 import cProfile
 from yaha import Cuttor, RegexCutting, SurnameCutting, SurnameCutting2, SuffixCutting
 from yaha.wordmaker import WordDict
 from yaha.analyse import extract_keywords, near_duplicate, summarize1, summarize2, summarize3
 
-str = '唐成真是唐成牛的长寿乡是个1998love唐成真诺维斯基'
+s = '唐成真是唐成牛的长寿乡是个1998love唐成真诺维斯基'
 cuttor = Cuttor()
 
 # Get 3 shortest paths for choise_best
-#cuttor.set_topk(3)
+cuttor.set_topk(3)
 
 # Use stage 1 to cut english and number 
 cuttor.set_stage1_regex(re.compile('(\d+)|([a-zA-Z]+)', re.I|re.U))
 
 # Or use stage 2 to cut english and number 
-#cuttor.add_stage(RegexCutting(re.compile('\d+', re.I|re.U)))
-#cuttor.add_stage(RegexCutting(re.compile('[a-zA-Z]+', re.I|re.U)))
+cuttor.add_stage(RegexCutting(re.compile('\d+', re.I|re.U)))
+cuttor.add_stage(RegexCutting(re.compile('[a-zA-Z]+', re.I|re.U)))
 
 # Use stage 3 to cut chinese name
-#surname = SurnameCutting()
-#cuttor.add_stage(surname)
+surname = SurnameCutting()
+cuttor.add_stage(surname)
 
 # Or use stage 4 to cut chinese name
 surname = SurnameCutting2()
@@ -30,36 +30,36 @@ cuttor.add_stage(surname)
 suffix = SuffixCutting()
 cuttor.add_stage(suffix)
 
-#seglist = cuttor.cut(str)
-#print '\nCut with name \n%s\n' % ','.join(list(seglist))
+seglist = cuttor.cut(s)
+print('\nCut with name \n%s\n' % ','.join(list(seglist)))
 
-#seglist = cuttor.cut_topk(str, 3)
-#for seg in seglist:
-#    print ','.join(seg)
+seglist = cuttor.cut_topk(s, 3)
+for seg in seglist:
+    print(','.join(seg))
 
-#for s in cuttor.cut_to_sentence(str):
-#    print s
+for s in cuttor.cut_to_sentence(s):
+    print(s)
 
-#str = "伟大祖国是中华人民共和国"
-#str = "九孔不好看来"
-#str = "而迈入社会后..."
-str = "工信处女干事每月经过下属科室都要亲口交代24口交换机等技术性器件的安装工作"
+#s = "伟大祖国是中华人民共和国"
+#s = "九孔不好看来"
+#s = "而迈入社会后..."
+s = "工信处女干事每月经过下属科室都要亲口交代24口交换机等技术性器件的安装工作"
 
 #You can set WORD_MAX to 8 for better match
-#cuttor.WORD_MAX = 8
+cuttor.WORD_MAX = 8
 
 #Normal cut
-seglist = cuttor.cut(str)
-print 'Normal cut \n%s\n' % ','.join(list(seglist))
+seglist = cuttor.cut(s)
+print(('Normal cut \n%s\n' % ','.join(list(seglist))))
 
 #All cut
-seglist = cuttor.cut_all(str)
-print 'All cut \n%s\n' % ','.join(list(seglist))
+seglist = cuttor.cut_all(s)
+print(('All cut \n%s\n' % ','.join(list(seglist))))
 
 #Tokenize for search
-print 'Cut for search (term,start,end)'
-for term, start, end in cuttor.tokenize(str.decode('utf-8'), search=True):
-    print term, start, end
+print('Cut for search (term,start,end)')
+for term, start, end in cuttor.tokenize(s, search=True):
+    print((term, start, end))
 
 re_line = re.compile("\W+|[a-zA-Z0-9]+", re.UNICODE)
 def sentence_from_file(filename):
@@ -75,17 +75,17 @@ def make_new_word(file_from, file_save):
         word_dict.learn(sentence)
     word_dict.learn_flush()
     
-    str = '我们的读书会也顺利举办了四期'
-    seg_list = word_dict.cut(str)
-    print ', '.join(seg_list)
+    s = '我们的读书会也顺利举办了四期'
+    seg_list = word_dict.cut(s)
+    print((', '.join(seg_list)))
 
     word_dict.save_to_file(file_save)
 
 #最大熵算法得到新词
-#def test():
-#   make_new_word('qq0', 'www_qq0')
-#cProfile.run('test()')
-#test()
+def test():
+   make_new_word('qq0', 'www_qq0')
+cProfile.run('test()')
+test()
 
 #test: Get key words from file
 def key_word_test():
@@ -93,15 +93,15 @@ def key_word_test():
     with codecs.open(filename, 'r', 'utf-8') as file:
         content = file.read()
         keys = extract_keywords(content)
-        #print ','.join(keys)
-        print summarize1(content)
-        print summarize2(content)
-        print summarize3(content)
-#key_word_test()
+        print(','.join(keys))
+        print((summarize1(content)))
+        print((summarize2(content)))
+        print((summarize3(content)))
+key_word_test()
 
 #比较文本的相似度
 def compare_file():
     file1 = codecs.open('f1.txt', 'r', 'utf-8')
     file2 = codecs.open('f2.txt', 'r', 'utf-8')
-    print 'the near of two files is:', near_duplicate(file1.read(), file2.read())
-#compare_file()
+    print(('the near of two files is:', near_duplicate(file1.read(), file2.read())))
+compare_file()

--- a/yaha/analyse/__init__.py
+++ b/yaha/analyse/__init__.py
@@ -8,8 +8,8 @@ from math import sqrt
 from yaha import DICTS, get_dict, Cuttor, cut_sentence
 try:
     import whoosh
-    from analyzer import ChineseAnalyzer
-    from spelling import words_train, YahaCorrector
+    from .analyzer import ChineseAnalyzer
+    from .spelling import words_train, YahaCorrector
 except ImportError:
     # install whoosh to using ChineseAnalyzer
     pass
@@ -44,7 +44,7 @@ def __init_idf():
             idf_freq[term] = frequency
             num_freqs += float(frequency)
 
-        for term,freq in idf_freq.iteritems():
+        for term,freq in idf_freq.items():
             idf_freq[term] = math.log(float(1 + num_docs) / (1 + freq))
 
     IDF_INIT = True
@@ -71,7 +71,7 @@ def extract_keywords(content, topk=18, cuttor=None):
         if len(word.strip()) < 2:
             continue
         lower_word = word.lower()
-        if stopwords.has_key(lower_word):
+        if lower_word in stopwords:
             continue
         #TODO only leave the 'n' word? 21/08/13 09:13:36
         if tmp_cuttor.exist(lower_word) and not tmp_cuttor.word_type(lower_word, 'n'):
@@ -81,7 +81,7 @@ def extract_keywords(content, topk=18, cuttor=None):
             freq[lower_word] += 1
         else:
             freq[lower_word] = 1
-    freq = [(k,v/total) for k,v in freq.iteritems()]
+    freq = [(k,v/total) for k,v in freq.items()]
     tf_idf_list = [(v * idf_freq.get(k,median_idf),k) for k,v in freq]
     st_list = sorted(tf_idf_list, reverse=True)
 
@@ -104,12 +104,12 @@ def near_duplicate(content1, content2, cuttor=None):
         is_drop = False
         lw = w.lower()
         for stopword in stopwords:
-            if stopword.has_key(lw):
+            if lw in stopword:
                 is_drop = True
                 break
             if is_drop:
                 continue
-            if lw not in file_words.keys():
+            if lw not in list(file_words.keys()):
                 file_words[lw] = [1,0]
             else:
                 file_words[lw][0] += 1
@@ -119,12 +119,12 @@ def near_duplicate(content1, content2, cuttor=None):
         is_drop = False
         lw = w.lower()
         for stopword in stopwords:
-            if stopword.has_key(lw):
+            if lw in stopword:
                 is_drop = True
                 break
             if is_drop:
                 continue
-            if lw not in file_words.keys():
+            if lw not in list(file_words.keys()):
                 file_words[lw] = [0,1]
             else:
                 file_words[lw][1] += 1
@@ -132,7 +132,7 @@ def near_duplicate(content1, content2, cuttor=None):
     sum_2 = 0
     sum_file1 = 0
     sum_file2 = 0
-    for word in file_words.values():
+    for word in list(file_words.values()):
         sum_2 += word[0]*word[1]
         sum_file1 += word[0]**2
         sum_file2 += word[1]**2
@@ -162,7 +162,7 @@ def summarize1(original_text, summary_size = 8, cuttor = None):
 
     for word in words_sorted:
         matching_sentence = __search_word(sentences, word)
-        if matching_sentence <> '':
+        if matching_sentence != '':
             summary_set[matching_sentence] = 1
             if len(summary_set) >= summary_size:
                 break
@@ -189,7 +189,7 @@ def __score_sentences(sentences, important_words, cuttor):
                 # Compute an index for where any important words occur in the sentence
 
                 word_idx.append(s.index(w))
-            except ValueError, e: # w not in this particular sentence
+            except ValueError as e: # w not in this particular sentence
                 pass
 
         word_idx.sort()
@@ -248,7 +248,7 @@ def summarize2(txt, cuttor=None):
     top_n_scored = sorted(top_n_scored, key=lambda s: s[0])
     top_n_summary=[sentences[idx] for (idx, score) in top_n_scored]
     #return ', '.join(top_n_summary) + '.'
-    return u'。 '.join(top_n_summary) + u'。 '
+    return '。 '.join(top_n_summary) + '。 '
 
 def _mean_std(l):
     ln = len(l)
@@ -280,4 +280,4 @@ def summarize3(txt, cuttor=None):
                    if score > avg + 0.5 * std]
     mean_scored_summary=[sentences[idx] for (idx, score) in mean_scored]
     #return ', '.join(mean_scored_summary) + '.'
-    return u'。 '.join(mean_scored_summary) + u'。 '
+    return '。 '.join(mean_scored_summary) + '。 '

--- a/yaha/analyse/analyzer.py
+++ b/yaha/analyse/analyzer.py
@@ -10,16 +10,16 @@ STOP_WORDS = None
 def __init_stop_words():
     global STOP_WORDS
     stop_words = []
-    for t,v in get_dict(DICTS.EXT_STOPWORD).iteritems():
+    for t,v in get_dict(DICTS.EXT_STOPWORD).items():
         stop_words.append(t)
-    for t,v in get_dict(DICTS.STOPWORD).iteritems():
+    for t,v in get_dict(DICTS.STOPWORD).items():
         stop_words.append(t)
-    for t,v in get_dict(DICTS.STOP_SENTENCE).iteritems():
+    for t,v in get_dict(DICTS.STOP_SENTENCE).items():
         stop_words.append(t)
     STOP_WORDS = frozenset(stop_words)
 __init_stop_words()
 
-accepted_chars = re.compile(ur"[\u4E00-\u9FA5]+")
+accepted_chars = re.compile(r"[\u4E00-\u9FA5]+")
 
 _cuttor = Cuttor()
 _cuttor.set_stage1_regex(re.compile('(\d+)|([a-zA-Z]+)', re.I|re.U))

--- a/yaha/analyse/spelling.py
+++ b/yaha/analyse/spelling.py
@@ -34,7 +34,7 @@ class YahaCorrector(whoosh_spelling.Corrector):
 
         heap = []
         seen = set()
-        for k in xrange(1, maxdist + 1):
+        for k in range(1, maxdist + 1):
             for item in _suggestions(text, k, prefix):
                 if item[1] in seen:
                     continue
@@ -55,7 +55,7 @@ class YahaCorrector(whoosh_spelling.Corrector):
         return [sug for _, sug in sugs]
 
     def _suggestions(self, text, maxdist, prefix):
-        if self.dict.has_key(text):
+        if text in self.dict:
             yield (len(text)*10 + self.dict.get(text,0)*5, text)
         for sug in fst.within(self.graph, text, k=maxdist, prefix=prefix):
             # Higher scores are better, so negate the edit distance
@@ -72,7 +72,7 @@ def words_train(in_file, word_file, graph_file):
         if file_size > 3*1024*1024:
             # A little more quick but inaccurate than WordDict1
             word_dict = WordDict2()
-            print >> sys.stderr, 'please wait, getting words from file', in_file
+            print('please wait, getting words from file', in_file, file=sys.stderr)
         else:
             word_dict = WordDict1()
         with codecs.open(in_file, 'r', 'utf-8') as file:
@@ -80,10 +80,10 @@ def words_train(in_file, word_file, graph_file):
                 for sentence in re_line.split(line):
                     word_dict.learn(sentence)
         word_dict.learn_flush()
-        print >> sys.stderr, 'get all words, save word to file', word_file
+        print('get all words, save word to file', word_file, file=sys.stderr)
         
         word_dict.save_to_file(word_file)
-        print >> sys.stderr, 'save all words completely, create word graphp', graph_file
+        print('save all words completely, create word graphp', graph_file, file=sys.stderr)
 
     words = []
     with codecs.open(word_file,'r','utf-8') as file:
@@ -94,4 +94,4 @@ def words_train(in_file, word_file, graph_file):
     words = sorted(words)
 
     whoosh_spelling.wordlist_to_graph_file(words, graph_file)
-    print >> sys.stderr, 'words_train ok'
+    print('words_train ok', file=sys.stderr)

--- a/yaha/ksp_dijkstra.py
+++ b/yaha/ksp_dijkstra.py
@@ -1,6 +1,6 @@
 # -*- coding=utf-8 -*-
 from operator import itemgetter
-from prioritydictionary import priorityDictionary
+from .prioritydictionary import priorityDictionary
 
 class Graph:
     INFINITY = 100000
@@ -9,7 +9,7 @@ class Graph:
     def __init__(self, n, default_prob):
         self._data = {}
         self.N = n
-        for i in xrange(0,n-1,1):
+        for i in range(0,n-1,1):
             self._data[i] = {}
             self._data[i][i+1] = default_prob
         self._data[n-1] = {}
@@ -21,7 +21,7 @@ class Graph:
         return (self._data)
 
     def __getitem__(self, node):
-        if self._data.has_key(node):
+        if node in self._data:
             return self._data[node]
         else:
             return None
@@ -29,8 +29,8 @@ class Graph:
     def __iter__(self):
         return self._data.__iter__()
 
-    def iteritems(self):
-        return self._data.iteritems()
+    def items(self):
+        return iter(self._data.items())
     
     def add_edge(self, node_from, node_to, cost=None):
         if not cost:
@@ -40,7 +40,7 @@ class Graph:
         return
     
     def remove_edge(self, node_from, node_to, cost=None):
-        if self._data[node_from].has_key(node_to):
+        if node_to in self._data[node_from]:
             if not cost:
                 cost = self._data[node_from][node_to]
                 
@@ -164,7 +164,7 @@ def quick_shortest(graph):
     previous[0] = None
     distances[N] = 0.0
 
-    for idx in xrange(N-1,-1,-1):
+    for idx in range(N-1,-1,-1):
         Q = priorityDictionary()
         for x in graph[idx]:
             Q[x] = graph[idx][x] + distances[x]

--- a/yaha/ksp_dp.py
+++ b/yaha/ksp_dp.py
@@ -1,6 +1,6 @@
 # -*- coding=utf-8 -*-
 from operator import itemgetter
-from prioritydictionary import priorityDictionary
+from .prioritydictionary import priorityDictionary
 
 class Graph:
     INFINITY = 10000
@@ -9,7 +9,7 @@ class Graph:
     def __init__(self, n):
         self._data = {}
         self.N = n
-        for i in xrange(0,n,1):
+        for i in range(0,n,1):
             self._data[i] = {}
 
     def __str__(self):
@@ -19,7 +19,7 @@ class Graph:
         return (self._data)
 
     def __getitem__(self, node):
-        if self._data.has_key(node):
+        if node in self._data:
             return self._data[node]
         else:
             return None
@@ -35,7 +35,7 @@ class Graph:
         return
     
     def remove_edge(self, node_from, node_to, cost=None):
-        if self._data[node_to].has_key(node_from):
+        if node_from in self._data[node_to]:
             if not cost:
                 cost = self._data[node_to][node_from]
                 
@@ -109,10 +109,10 @@ def dp_graph(graph, node_start, node_end=None):
     previous = {}
     
     previous[node_start] = None
-    for idx in xrange(0, node_start+1, 1):
+    for idx in range(0, node_start+1, 1):
         distances[idx] = 0.0
 
-    for idx in xrange(node_start+1,N,1):
+    for idx in range(node_start+1,N,1):
         Q = priorityDictionary()
         for x in graph[idx]:
             Q[x] = distances[x] + graph[idx][x]

--- a/yaha/prioritydictionary.py
+++ b/yaha/prioritydictionary.py
@@ -21,7 +21,7 @@
 #
 # http://code.activestate.com/recipes/117228/
 # 
-from __future__ import generators
+
 
 class priorityDictionary(dict):
     def __init__(self):
@@ -35,7 +35,7 @@ class priorityDictionary(dict):
     def smallest(self):
         '''Find smallest item after removing deleted items from heap.'''
         if len(self) == 0:
-            raise IndexError, "smallest of empty priorityDictionary"
+            raise IndexError("smallest of empty priorityDictionary")
         heap = self.__heap
         while heap[0][1] not in self or self[heap[0][1]] != heap[0][0]:
             lastItem = heap.pop()
@@ -68,7 +68,7 @@ class priorityDictionary(dict):
         dict.__setitem__(self,key,val)
         heap = self.__heap
         if len(heap) > 2 * len(self):
-            self.__heap = [(v,k) for k,v in self.iteritems()]
+            self.__heap = [(v,k) for k,v in self.items()]
             self.__heap.sort()  # builtin sort likely faster than O(n) heapify
         else:
             newPair = (val,key)

--- a/yaha/wordmaker.py
+++ b/yaha/wordmaker.py
@@ -87,7 +87,7 @@ def get_modified_dict():
 
 def info_entropy(words, total):
     result = 0 
-    for word, cnt in words.iteritems():
+    for word, cnt in words.items():
         p = float(cnt) / total
         result -= p * math.log(p)
     return result
@@ -105,8 +105,8 @@ class Process(object):
         l = len(sentence)
         wl = min(l, max_word_len)
         self.cache_lines.append(sentence)
-        for i in xrange(1, wl + 1): 
-            for j in xrange(0, l - i + 1): 
+        for i in range(1, wl + 1): 
+            for j in range(0, l - i + 1): 
                 if j == 0:
                     if j < l-i:
                         word_dict.add_word_r(sentence[j:j+i], sentence[j+i])
@@ -129,7 +129,7 @@ class Process(object):
             this_word = word_dict.get_word(word)
             if len(word) > 1:
                 p = 0
-                for i in xrange(1, len(word)):
+                for i in range(1, len(word)):
                     t = word_dict.ps(word[0:i]) * word_dict.ps(word[i:])
                     p = max(p, t)
                 if p > 0 and this_word.process_freq >= 3 and this_word.process_ps / p > 100:
@@ -193,7 +193,7 @@ class WordDict(BaseCuttor):
                         self.dict[word] = this_word
                         self.base_total += freq
         #normalize
-        for word, term in self.dict.iteritems():
+        for word, term in self.dict.items():
             term.base_ps = math.log(float(term.base_freq)/self.base_total)
             term.curr_ps = term.base_ps
     
@@ -278,7 +278,7 @@ class WordDict(BaseCuttor):
         word_dict = self
         if sorted:
             final_words = []
-            for word, term in word_dict.dict.iteritems():
+            for word, term in word_dict.dict.items():
                 #if term.valid > word_dict.id/2 and term.base_freq == 0:
                 # Use this to save more word
                 if term.valid > 0 and term.base_freq == 0:
@@ -292,7 +292,7 @@ class WordDict(BaseCuttor):
                     file.write("%s %d\n" % (word,v))
         else:
             with codecs.open(filename,'w','utf-8') as file:
-                for word, term in word_dict.dict.iteritems():
+                for word, term in word_dict.dict.items():
                     if term.valid > 0 and term.base_freq == 0:
                         file.write("%s %d\n" % (word,term.total_freq))
 

--- a/yaha/wordmaker2.py
+++ b/yaha/wordmaker2.py
@@ -86,7 +86,7 @@ def get_modified_dict():
 
 def info_entropy(words, total):
     result = 0 
-    for word, cnt in words.iteritems():
+    for word, cnt in words.items():
         p = float(cnt) / total
         result -= p * math.log(p)
     return result
@@ -99,7 +99,7 @@ class Process(object):
     
     def add_word(self, word):
         this_word = None
-        if self.dict.has_key(word):
+        if word in self.dict:
             this_word = self.dict[word]
             this_word.add()
         else:
@@ -122,7 +122,7 @@ class Process(object):
         w.add_r(r)
 
     def ps(self, word):
-        if self.dict.has_key(word):
+        if word in self.dict:
             return self.dict[word].process_ps
         else:
             return 0.0
@@ -130,8 +130,8 @@ class Process(object):
     def do_sentence(self, sentence):
         l = len(sentence)
         wl = min(l, max_word_len)
-        for i in xrange(1, wl + 1): 
-            for j in xrange(0, l - i + 1): 
+        for i in range(1, wl + 1): 
+            for j in range(0, l - i + 1): 
                 if j == 0:
                     if j < l-i:
                         self.add_word_r(sentence[j:j+i], sentence[j+i])
@@ -145,14 +145,14 @@ class Process(object):
 
     def calc(self, word_dict):
         # calc all ps first
-        for word,this_word in self.dict.iteritems():
+        for word,this_word in self.dict.items():
             this_word.process_ps = float(this_word.process_freq)/self.process_total
     
         # then calc the ps around the word
-        for word,this_word in self.dict.iteritems():
+        for word,this_word in self.dict.items():
             if len(word) > 1:
                 p = 0
-                for i in xrange(1, len(word)):
+                for i in range(1, len(word)):
                     t = self.ps(word[0:i]) * self.ps(word[i:])
                     p = max(p, t)
                 if p > 0 and this_word.process_freq >= 3 and this_word.process_ps / p > 100:
@@ -215,13 +215,13 @@ class WordDict(BaseCuttor):
                         self.dict[word] = this_word
                         self.base_total += freq
         #normalize
-        for word, term in self.dict.iteritems():
+        for word, term in self.dict.items():
             term.base_ps = math.log(float(term.base_freq)/self.base_total)
             term.curr_ps = term.base_ps
 
     def add_valid(self, word, pword):
         this_word = None
-        if self.dict.has_key(word):
+        if word in self.dict:
             this_word = self.dict[word]
         else:
             this_word = Word()
@@ -277,7 +277,7 @@ class WordDict(BaseCuttor):
         word_dict = self
         if sorted:
             final_words = []
-            for word, term in word_dict.dict.iteritems():
+            for word, term in word_dict.dict.items():
                 #if term.valid > word_dict.id/2 and term.base_freq == 0:
                 # Use this to save more word
                 if term.valid > 0 and term.base_freq == 0:
@@ -291,7 +291,7 @@ class WordDict(BaseCuttor):
                     file.write("%s %d\n" % (word,v))
         else:
             with codecs.open(filename,'w','utf-8') as file:
-                for word, term in word_dict.dict.iteritems():
+                for word, term in word_dict.dict.items():
                     if term.valid > 0 and term.base_freq == 0:
                         file.write("%s %d\n" % (word,term.total_freq))
 


### PR DESCRIPTION
Make yaha compatible with py3. 
test_cuttor.py can be run successfully.

Note: 
yaha/analyse/spelling.py needs the module whoosh.automata.fst, which is missing in py3 version of whoosh.